### PR TITLE
fix(hy2): dialer regression introduced by #21 pr

### DIFF
--- a/dialer/hysteria2/hysteria2.go
+++ b/dialer/hysteria2/hysteria2.go
@@ -59,6 +59,7 @@ func (s *Hysteria2) Dialer(option *dialer.ExtraOption, nextDialer netproxy.Diale
 	}
 	if header.SNI == "" {
 		header.SNI = s.Server
+		header.TlsConfig.ServerName = s.Server
 	}
 	if s.MaxTx > 0 && s.MaxRx > 0 {
 		header.Feature1 = &client.BandwidthConfig{


### PR DESCRIPTION
test uri: `'hy2://a@b.com:9527'`

before this patch:

```
level=debug msg="Connectivity Check Failed" err="connect error: CRYPTO_ERROR 0x150 (remote): tls: internal error" network="tcp6(DNS)" node=kr02
level=debug msg="Connectivity Check Failed" err="connect error: CRYPTO_ERROR 0x150 (remote): tls: internal error" network="udp6(DNS)" node=kr02
level=debug msg="Connectivity Check Failed" err="connect error: CRYPTO_ERROR 0x150 (remote): tls: internal error" network="udp4(DNS)" node=kr02
level=debug msg="Connectivity Check Failed" err="connect error: CRYPTO_ERROR 0x150 (remote): tls: internal error" network="tcp4(DNS)" node=kr02
```

after this patch:

```
level=info msg="Group selects dialer" dialer=kr02 group=final network=tcp4
level=info msg="Group selects dialer" dialer=kr02 group=final network=tcp6
level=info msg="Group selects dialer" dialer=kr02 group=final network="udp4(DNS)"
level=info msg="Group selects dialer" dialer=kr02 group=final network="udp6(DNS)"
level=info msg="Group selects dialer" dialer=kr02 group=final network="tcp4(DNS)"
level=info msg="Group selects dialer" dialer=kr02 group=final network="tcp6(DNS)"
```
this is actually a partial revert of #21:

![图片](https://github.com/user-attachments/assets/a0546806-3521-45c6-b4e6-bef22e5862e1)

any thoughts here? @mnixry 
