### PR TITLE
fix(trojan): websocket path loss

### DIFF
--- a/dialer/trojan/trojan.go
+++ b/dialer/trojan/trojan.go
@@ -70,9 +70,9 @@ func (s *Trojan) Dialer(option *dialer.ExtraOption, nextDialer netproxy.Dialer) 
 		u := url.URL{
 			Scheme: "ws",
 			Host:   net.JoinHostPort(s.Server, strconv.Itoa(s.Port)),
+			Path:   s.Path,
 			RawQuery: url.Values{
 				"host": []string{s.Host},
-				"path": []string{s.Path},
 			}.Encode(),
 		}
 		if d, _, err = ws.NewWs(option, d, u.String()); err != nil {


### PR DESCRIPTION
Because the Path variable is located in the wrong position, the path of the websocket connection is empty