### PR TITLE
fix: close of closed channel

### DIFF
--- a/protocol/shadowsocks/salt_generator.go
+++ b/protocol/shadowsocks/salt_generator.go
@@ -62,7 +62,7 @@ func GetSaltGenerator(masterKey []byte, saltLen int) (sg SaltGenerator, err erro
 	} else {
 		muGenerators.Unlock()
 		if g, isBuilding := sg.(*DummySaltGenerator); isBuilding {
-			for g.Closed {
+			for !g.Closed {
 				// spinning
 			}
 			if g.Success {


### PR DESCRIPTION
# Background

```
1月 28 16:23:39 CSL-MacBook-Pro daed[910]: goroutine 23791 [running]:
1月 28 16:23:39 CSL-MacBook-Pro daed[910]: github.com/daeuniverse/outbound/transport/grpc.(*ClientConn).Close(0xc00304db00)
1月 28 16:23:39 CSL-MacBook-Pro daed[910]:         github.com/daeuniverse/outbound@v0.0.0-20241203160254-b61700645a6c/transport/grpc/grpc_client.go:169 +0x3a
1月 28 16:23:39 CSL-MacBook-Pro daed[910]: github.com/daeuniverse/outbound/protocol/vmess.(*Conn).Close(0xc0027897e0?)
1月 28 16:23:39 CSL-MacBook-Pro daed[910]:         github.com/daeuniverse/outbound@v0.0.0-20241203160254-b61700645a6c/protocol/vmess/conn.go:80 +0x1b
1月 28 16:23:39 CSL-MacBook-Pro daed[910]: github.com/daeuniverse/dae/control.(*DoTCP).Close(0xc0038e4180?)
1月 28 16:23:39 CSL-MacBook-Pro daed[910]:         github.com/daeuniverse/dae@v0.2.0/control/dns.go:290 +0x27
1月 28 16:23:39 CSL-MacBook-Pro daed[910]: github.com/daeuniverse/dae/control.(*DnsController).dialSend(0xc002c8b4d0, 0x0, 0xc000251f10, {0xc0030584e0, 0x24, 0x25}, 0x260e, 0xc003496440?, 0x1)
1月 28 16:23:39 CSL-MacBook-Pro daed[910]:         github.com/daeuniverse/dae@v0.2.0/control/dns_control.go:592 +0x5d3
1月 28 16:23:39 CSL-MacBook-Pro daed[910]: github.com/daeuniverse/dae/control.(*DnsController).handle_(0xc002c8b4d0, 0xc0030a39e0, 0xc000251f10, 0x1)
1月 28 16:23:39 CSL-MacBook-Pro daed[910]:         github.com/daeuniverse/dae@v0.2.0/control/dns_control.go:489 +0x919
1月 28 16:23:39 CSL-MacBook-Pro daed[910]: github.com/daeuniverse/dae/control.(*DnsController).Handle_(0xc002c8b4d0, 0xc0030a39e0, 0xc000251f10)
1月 28 16:23:39 CSL-MacBook-Pro daed[910]:         github.com/daeuniverse/dae@v0.2.0/control/dns_control.go:373 +0x6ed
1月 28 16:23:39 CSL-MacBook-Pro daed[910]: github.com/daeuniverse/dae/control.(*ControlPlane).handlePkt(0xc002712120, 0xc00079e020, {0xc0025ae380, 0x24, 0x40}, {{{0xc0038cde88?, 0x0?}, {0xc000130a20?}}, 0x1c0?}, {{{0x0, ...}, ...}, ...}, ...)
1月 28 16:23:39 CSL-MacBook-Pro daed[910]:         github.com/daeuniverse/dae@v0.2.0/control/udp.go:156 +0x14d7
1月 28 16:23:39 CSL-MacBook-Pro daed[910]: github.com/daeuniverse/dae/control.(*ControlPlane).Serve.func5.1()
1月 28 16:23:39 CSL-MacBook-Pro daed[910]:         github.com/daeuniverse/dae@v0.2.0/control/control_plane.go:837 +0x38c
1月 28 16:23:39 CSL-MacBook-Pro daed[910]: github.com/daeuniverse/dae/control.(*UdpTaskQueue).convoy(0xc003aa8100)
1月 28 16:23:39 CSL-MacBook-Pro daed[910]:         github.com/daeuniverse/dae@v0.2.0/control/udp_task_pool.go:52 +0x3d
1月 28 16:23:39 CSL-MacBook-Pro daed[910]: created by github.com/daeuniverse/dae/control.(*UdpTaskPool).EmitTask in goroutine 42
1月 28 16:23:39 CSL-MacBook-Pro daed[910]:         github.com/daeuniverse/dae@v0.2.0/control/udp_task_pool.go:109 +0x28b
1月 28 16:23:39 CSL-MacBook-Pro systemd[1]: daed.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
1月 28 16:23:39 CSL-MacBook-Pro systemd[1]: daed.service: Failed with result 'exit-code'.

```