### PR TITLE
optimize: add cache for direct dialer

### DIFF
--- a/dialer/v2ray/v2ray.go
+++ b/dialer/v2ray/v2ray.go
@@ -12,7 +12,6 @@ import (
 	"github.com/daeuniverse/outbound/dialer"
 	"github.com/daeuniverse/outbound/netproxy"
 	"github.com/daeuniverse/outbound/protocol"
-	"github.com/daeuniverse/outbound/protocol/direct"
 	"github.com/daeuniverse/outbound/protocol/http"
 	"github.com/daeuniverse/outbound/transport/grpc"
 	"github.com/daeuniverse/outbound/transport/httpupgrade"
@@ -190,7 +189,7 @@ func (s *V2Ray) Dialer(option *dialer.ExtraOption, nextDialer netproxy.Dialer) (
 				"transport":         []string{"1"},
 			}.Encode(),
 		}
-		d, err = http.NewHTTPProxy(&u, direct.SymmetricDirect)
+		d, err = http.NewHTTPProxy(&u, d)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
# 背景

有一种可能的循环依赖情况：
dae 在解析节点域名的时候走了 resolv.conf，然后到了本地的 smartdns，smartdns 用国外 doh 被劫持代理到 dae，而代理需要过节点，而过节点需要解析节点域名……

# 改动

本次为 direct dialer 添加一个选项 `WithCache`，该选项开启后，会记录 direct dialer 的上次成功的 host 对应的 ip，并在因dns查询而失败时对相同 host 用缓存的 ip 进行重试