### PR TITLE
Fix anytls dialer: set node name to URL fragment and parse parameter 'peer' as 'sni'

### DIFF
--- a/dialer/anytls/anytls.go
+++ b/dialer/anytls/anytls.go
@@ -16,6 +16,7 @@ func init() {
 
 type Anytls struct {
 	link     string
+	Name     string
 	Auth     string
 	Host     string
 	Sni      string
@@ -36,15 +37,23 @@ func NewAnytls(option *dialer.ExtraOption, nextDialer netproxy.Dialer, link stri
 }
 
 func parseAnytlsURL(link string) (*Anytls, error) {
-	u, err := url.ParseRequestURI(link)
+	u, err := url.Parse(link)
 	if err != nil {
 		return nil, err
 	}
+        sni := u.Query().Get("peer")
+	if sni == "" {
+		sni = u.Query().Get("sni")
+	}
+	if sni == "" {
+		sni = u.Hostname()
+	}
 	antls := &Anytls{
 		link:     link,
+		Name:     u.Fragment,
 		Auth:     u.User.Username(),
 		Host:     u.Host,
-		Sni:      u.Query().Get("sni"),
+		Sni:      sni,
 		Insecure: u.Query().Get("insecure") == "1",
 	}
 
@@ -70,7 +79,7 @@ func (s *Anytls) Dialer(option *dialer.ExtraOption, nextDialer netproxy.Dialer) 
 		return nil, nil, err
 	}
 	return d, &dialer.Property{
-		Name:     "anytls",
+		Name:     s.Name,
 		Protocol: "anytls",
 		Address:  s.Host,
 		Link:     s.link,


### PR DESCRIPTION
Subscriptions from some airport could be in the following format:
  anytls://abcde@blah.blah.org:23326?peer=blah.blah.com&insecure=1&alpn=h2&udp=1#Node Name

This PR tries to fix 2 issues in outbound anytls dialer:
 - Hard-coded name as 'anytls', which is unfriendly to airport subscription contains multiple anytls nodes.
 - 'peer' parameter is not recognized. (Trojan dailer can recognize both 'peer' and 'sni')
