### PR TITLE
hysteria2: refactor dialer to return server address in connection factory

### DIFF
--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -19,7 +19,7 @@ type ExtraOption struct {
 	UtlsImitate         string
 	BandwidthMaxTx      string
 	BandwidthMaxRx      string
-	UDPHopInterval    time.Duration
+	UDPHopInterval      time.Duration
 }
 
 type Property struct {

--- a/pkg/cert/cert_pool_windows.go
+++ b/pkg/cert/cert_pool_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package cert

--- a/protocol/hysteria2/client/client.go
+++ b/protocol/hysteria2/client/client.go
@@ -59,7 +59,7 @@ type clientImpl struct {
 }
 
 func (c *clientImpl) connect(ctx context.Context) (*HandshakeInfo, error) {
-	pktConn, err := c.config.ConnFactory.New(ctx)
+	pktConn, serverAddr, err := c.config.ConnFactory.New(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (c *clientImpl) connect(ctx context.Context) (*HandshakeInfo, error) {
 		TLSClientConfig: tlsConfig,
 		QUICConfig:      quicConfig,
 		Dial: func(ctx context.Context, _ string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error) {
-			qc, err := quic.DialEarly(ctx, pktConn, c.config.ServerAddr, tlsCfg, cfg)
+			qc, err := quic.DialEarly(ctx, pktConn, serverAddr, tlsCfg, cfg)
 			if err != nil {
 				return nil, err
 			}

--- a/protocol/hysteria2/client/config.go
+++ b/protocol/hysteria2/client/config.go
@@ -19,7 +19,6 @@ const (
 
 type Config struct {
 	ConnFactory     ConnFactory
-	ServerAddr      net.Addr
 	Auth            string
 	TLSConfig       TLSConfig
 	QUICConfig      QUICConfig
@@ -38,9 +37,6 @@ func (c *Config) verifyAndFill() error {
 	}
 	if c.ConnFactory == nil {
 		return errors.ConfigError{Field: "ConnFactory", Reason: "must be set"}
-	}
-	if c.ServerAddr == nil {
-		return errors.ConfigError{Field: "ServerAddr", Reason: "must be set"}
 	}
 	if c.QUICConfig.InitialStreamReceiveWindow == 0 {
 		c.QUICConfig.InitialStreamReceiveWindow = defaultStreamReceiveWindow
@@ -79,14 +75,14 @@ func (c *Config) verifyAndFill() error {
 }
 
 type ConnFactory interface {
-	New(context.Context) (net.PacketConn, error)
+	New(context.Context) (net.PacketConn, net.Addr, error)
 }
 
 type UdpConnFactory struct {
-	NewFunc func(ctx context.Context) (net.PacketConn, error)
+	NewFunc func(ctx context.Context) (net.PacketConn, net.Addr, error)
 }
 
-func (f *UdpConnFactory) New(ctx context.Context) (net.PacketConn, error) {
+func (f *UdpConnFactory) New(ctx context.Context) (net.PacketConn, net.Addr, error) {
 	return f.NewFunc(ctx)
 }
 

--- a/transport/shadowsocksr/obfs/obfs.go
+++ b/transport/shadowsocksr/obfs/obfs.go
@@ -7,7 +7,7 @@ import (
 type Creator func() IObfs
 
 type constructor struct {
-	New Creator
+	New      Creator
 	Overhead int
 }
 


### PR DESCRIPTION
This PR fixes an issue where the dialer fails to create if the initial DNS lookup is unsuccessful. This is problematic because DNS failures can be transient. With this change, DNS resolution is deferred until connection time, making the dialer creation more reliable.

Additionally, this addresses a limitation where the dialer does not adapt to on-the-fly changes in the target server's IP address. The new implementation ensures the dialer can handle dynamic DNS updates.

Not tested yet.

/cc @LostAttractor