### PR TITLE
fix(hy2): defer server resolution

### DIFF
--- a/protocol/hysteria2/dialer.go
+++ b/protocol/hysteria2/dialer.go
@@ -28,8 +28,22 @@ type Feature1 struct {
 	UDPHopInterval  time.Duration
 }
 
+type unresolvedServerAddr struct {
+	network string
+	address string
+}
+
+func (a *unresolvedServerAddr) Network() string {
+	return a.network
+}
+
+func (a *unresolvedServerAddr) String() string {
+	return a.address
+}
+
 func NewDialer(nextDialer netproxy.Dialer, header protocol.Header) (netproxy.Dialer, error) {
 	host, port, hostPort := parseServerAddrString(header.ProxyAddress)
+	isPortHopping := isPortHoppingPort(port)
 
 	metadata := protocol.Metadata{
 		IsClient: header.IsClient,
@@ -56,19 +70,15 @@ func NewDialer(nextDialer netproxy.Dialer, header protocol.Header) (netproxy.Dia
 		config.UDPHopInterval = feature.(*Feature1).UDPHopInterval
 	}
 
-	var err error
-	if !isPortHoppingPort(port) {
-		config.ServerAddr, err = net.ResolveUDPAddr("udp", hostPort)
-	} else {
-		config.ServerAddr, err = udphop.ResolveUDPHopAddr(hostPort)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	if config.ServerAddr.Network() == "udphop" {
+	if isPortHopping {
+		config.ServerAddr = &unresolvedServerAddr{network: "udphop", address: hostPort}
 		config.ConnFactory = &client.UdpConnFactory{
 			NewFunc: func(ctx context.Context) (net.PacketConn, error) {
+				serverAddr, err := udphop.ResolveUDPHopAddr(hostPort)
+				if err != nil {
+					return nil, err
+				}
+				config.ServerAddr = serverAddr
 				dialFunc := func(addr net.Addr) (net.PacketConn, error) {
 					conn, err := nextDialer.DialContext(ctx, "udp", addr.String())
 					if err != nil {
@@ -80,20 +90,26 @@ func NewDialer(nextDialer netproxy.Dialer, header protocol.Header) (netproxy.Dia
 						addr,
 					), nil
 				}
-				return udphop.NewUDPHopPacketConn(config.ServerAddr.(*udphop.UDPHopAddr), config.UDPHopInterval, dialFunc)
+				return udphop.NewUDPHopPacketConn(serverAddr, config.UDPHopInterval, dialFunc)
 			},
 		}
 	} else {
+		config.ServerAddr = &unresolvedServerAddr{network: "udp", address: hostPort}
 		config.ConnFactory = &client.UdpConnFactory{
 			NewFunc: func(ctx context.Context) (net.PacketConn, error) {
-				conn, err := nextDialer.DialContext(ctx, "udp", config.ServerAddr.String())
+				serverAddr, err := net.ResolveUDPAddr("udp", hostPort)
+				if err != nil {
+					return nil, err
+				}
+				config.ServerAddr = serverAddr
+				conn, err := nextDialer.DialContext(ctx, "udp", serverAddr.String())
 				if err != nil {
 					return nil, err
 				}
 				return netproxy.NewFakeNetPacketConn(
 					conn.(netproxy.PacketConn),
 					net.UDPAddrFromAddrPort(common.GetUniqueFakeAddrPort()),
-					config.ServerAddr,
+					serverAddr,
 				), nil
 			},
 		}

--- a/protocol/hysteria2/dialer_test.go
+++ b/protocol/hysteria2/dialer_test.go
@@ -91,3 +91,22 @@ func TestUDP(t *testing.T) {
 	}
 	t.Log(ips)
 }
+
+func TestNewDialerDefersServerResolution(t *testing.T) {
+	for _, proxyAddress := range []string{
+		"unresolvable.invalid:443",
+		"unresolvable.invalid:20000-20010",
+	} {
+		t.Run(proxyAddress, func(t *testing.T) {
+			_, err := NewDialer(direct.SymmetricDirect, protocol.Header{
+				ProxyAddress: proxyAddress,
+				TlsConfig:    &tls.Config{ServerName: "example.com"},
+				User:         "auth",
+				IsClient:     true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- defer hysteria2 server address resolution until connection setup
- keep UDP port hopping support while avoiding DNS lookup during dialer construction
- add a regression test covering unresolved normal and port-hopping hostnames

## Root cause

The port-hopping change resolved hysteria2 hostnames in `NewDialer`, so dae node loading could fail before dae DNS initialization finished.

## Validation

- `GOCACHE=/tmp/codex-go-cache GOMODCACHE=/tmp/codex-go-mod go test ./protocol/hysteria2 -run TestNewDialerDefersServerResolution -count=1`
