### PR TITLE
feat(hy2): support salamander obfuscation

### DIFF
--- a/dialer/hysteria2/hysteria2.go
+++ b/dialer/hysteria2/hysteria2.go
@@ -28,6 +28,8 @@ type Hysteria2 struct {
 	User      string
 	Password  string
 	Server    string
+	Obfs      string
+	ObfsPass  string
 	Insecure  bool
 	Sni       string
 	PinSHA256 string
@@ -81,6 +83,12 @@ func (s *Hysteria2) Dialer(option *dialer.ExtraOption, nextDialer netproxy.Diale
 			}
 		}
 	}
+	if s.Obfs != "" {
+		feature1.ObfuscationConfig = client.ObfuscationConfig{
+			Obfuscation:    s.Obfs,
+			ObfuscationKey: []byte(s.ObfsPass),
+		}
+	}
 	header.Feature1 = feature1
 
 	if s.PinSHA256 != "" {
@@ -120,7 +128,6 @@ func normalizeCertHash(hash string) string {
 
 // ref: https://v2.hysteria.network/zh/docs/developers/URI-Scheme/
 func ParseHysteria2URL(link string) (*Hysteria2, error) {
-	// TODO: support salamander obfuscation
 	u, err := url.Parse(link)
 	if err != nil {
 		return nil, err
@@ -148,6 +155,8 @@ func ParseHysteria2URL(link string) (*Hysteria2, error) {
 		Name:      u.Fragment,
 		User:      u.User.Username(),
 		Server:    u.Host,
+		Obfs:      strings.ToLower(q.Get("obfs")),
+		ObfsPass:  q.Get("obfs-password"),
 		Insecure:  insecure,
 		Sni:       q.Get("sni"),
 		PinSHA256: q.Get("pinSHA256"),
@@ -177,6 +186,12 @@ func (s *Hysteria2) ExportToURL() string {
 	}
 	if s.PinSHA256 != "" {
 		q.Set("pinSHA256", s.PinSHA256)
+	}
+	if s.Obfs != "" {
+		q.Set("obfs", s.Obfs)
+	}
+	if s.ObfsPass != "" {
+		q.Set("obfs-password", s.ObfsPass)
 	}
 	if s.MaxTx > 0 && s.MaxRx > 0 {
 		q.Set("maxTx", strconv.FormatUint(s.MaxTx, 10))

--- a/protocol/hysteria2/client/client.go
+++ b/protocol/hysteria2/client/client.go
@@ -63,6 +63,18 @@ func (c *clientImpl) connect(ctx context.Context) (*HandshakeInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	switch c.config.ObfuscationConfig.Obfuscation {
+	case "salamander":
+		pktConn, err = newSalamanderPacketConn(pktConn, c.config.ObfuscationConfig.ObfuscationKey)
+		if err != nil {
+			_ = pktConn.Close()
+			return nil, err
+		}
+	case "", "plain":
+	default:
+		_ = pktConn.Close()
+		return nil, errors.New("unknown obfuscation: " + c.config.ObfuscationConfig.Obfuscation)
+	}
 	// Convert config to TLS config & QUIC config
 	tlsConfig := &tls.Config{
 		ServerName:            c.config.TLSConfig.ServerName,

--- a/protocol/hysteria2/client/config.go
+++ b/protocol/hysteria2/client/config.go
@@ -3,7 +3,9 @@ package client
 import (
 	"context"
 	"crypto/x509"
+	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/daeuniverse/outbound/protocol/hysteria2/errors"
@@ -18,14 +20,15 @@ const (
 )
 
 type Config struct {
-	ConnFactory     ConnFactory
-	ServerAddr      net.Addr
-	Auth            string
-	TLSConfig       TLSConfig
-	QUICConfig      QUICConfig
-	BandwidthConfig BandwidthConfig
-	UDPHopInterval  time.Duration
-	FastOpen        bool
+	ConnFactory       ConnFactory
+	ServerAddr        net.Addr
+	Auth              string
+	TLSConfig         TLSConfig
+	QUICConfig        QUICConfig
+	BandwidthConfig   BandwidthConfig
+	ObfuscationConfig ObfuscationConfig
+	UDPHopInterval    time.Duration
+	FastOpen          bool
 
 	filled bool // whether the fields have been verified and filled
 }
@@ -72,6 +75,19 @@ func (c *Config) verifyAndFill() error {
 	} else if c.QUICConfig.KeepAlivePeriod < 2*time.Second || c.QUICConfig.KeepAlivePeriod > 60*time.Second {
 		return errors.ConfigError{Field: "QUICConfig.KeepAlivePeriod", Reason: "must be between 2s and 60s"}
 	}
+	c.ObfuscationConfig.Obfuscation = strings.ToLower(c.ObfuscationConfig.Obfuscation)
+	switch c.ObfuscationConfig.Obfuscation {
+	case "", "plain":
+	case "salamander":
+		if len(c.ObfuscationConfig.ObfuscationKey) < salamanderPSKMinLen {
+			return errors.ConfigError{
+				Field:  "ObfuscationConfig.ObfuscationKey",
+				Reason: fmt.Sprintf("must be at least %d bytes for salamander", salamanderPSKMinLen),
+			}
+		}
+	default:
+		return errors.ConfigError{Field: "ObfuscationConfig.Obfuscation", Reason: "unsupported obfuscation method"}
+	}
 	c.QUICConfig.DisablePathMTUDiscovery = c.QUICConfig.DisablePathMTUDiscovery || pmtud.DisablePathMTUDiscovery
 
 	c.filled = true
@@ -113,4 +129,9 @@ type QUICConfig struct {
 type BandwidthConfig struct {
 	MaxTx uint64
 	MaxRx uint64
+}
+
+type ObfuscationConfig struct {
+	Obfuscation    string
+	ObfuscationKey []byte
 }

--- a/protocol/hysteria2/client/salamander.go
+++ b/protocol/hysteria2/client/salamander.go
@@ -1,0 +1,184 @@
+package client
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+const (
+	salamanderPSKMinLen = 4
+	salamanderSaltLen   = 8
+	salamanderKeyLen    = blake2b.Size256
+	udpBufferSize       = 2048
+)
+
+var errSalamanderPSKTooShort = fmt.Errorf("PSK must be at least %d bytes", salamanderPSKMinLen)
+
+type packetObfuscator interface {
+	Obfuscate(in, out []byte) int
+	Deobfuscate(in, out []byte) int
+}
+
+type salamanderObfuscator struct {
+	psk     []byte
+	randSrc *rand.Rand
+
+	mu       sync.Mutex
+	keyInput []byte
+}
+
+func newSalamanderObfuscator(psk []byte) (*salamanderObfuscator, error) {
+	if len(psk) < salamanderPSKMinLen {
+		return nil, errSalamanderPSKTooShort
+	}
+	pskCopy := append([]byte(nil), psk...)
+	keyInput := make([]byte, len(pskCopy)+salamanderSaltLen)
+	copy(keyInput, pskCopy)
+	return &salamanderObfuscator{
+		psk:      pskCopy,
+		randSrc:  rand.New(rand.NewSource(time.Now().UnixNano())),
+		keyInput: keyInput,
+	}, nil
+}
+
+func (o *salamanderObfuscator) Obfuscate(in, out []byte) int {
+	outLen := len(in) + salamanderSaltLen
+	if len(out) < outLen {
+		return 0
+	}
+	o.mu.Lock()
+	_, _ = o.randSrc.Read(out[:salamanderSaltLen])
+	key := o.keyLocked(out[:salamanderSaltLen])
+	o.mu.Unlock()
+	for i, b := range in {
+		out[i+salamanderSaltLen] = b ^ key[i%salamanderKeyLen]
+	}
+	return outLen
+}
+
+func (o *salamanderObfuscator) Deobfuscate(in, out []byte) int {
+	outLen := len(in) - salamanderSaltLen
+	if outLen <= 0 || len(out) < outLen {
+		return 0
+	}
+	o.mu.Lock()
+	key := o.keyLocked(in[:salamanderSaltLen])
+	o.mu.Unlock()
+	for i, b := range in[salamanderSaltLen:] {
+		out[i] = b ^ key[i%salamanderKeyLen]
+	}
+	return outLen
+}
+
+func (o *salamanderObfuscator) keyLocked(salt []byte) [salamanderKeyLen]byte {
+	copy(o.keyInput[len(o.psk):], salt[:salamanderSaltLen])
+	return blake2b.Sum256(o.keyInput)
+}
+
+type obfsPacketConn struct {
+	conn net.PacketConn
+	obfs packetObfuscator
+
+	readBuf    []byte
+	readMutex  sync.Mutex
+	writeBuf   []byte
+	writeMutex sync.Mutex
+}
+
+type obfsPacketConnUDP struct {
+	*obfsPacketConn
+	udpConn *net.UDPConn
+}
+
+func newObfsPacketConn(conn net.PacketConn, obfs packetObfuscator) net.PacketConn {
+	obfsConn := &obfsPacketConn{
+		conn:     conn,
+		obfs:     obfs,
+		readBuf:  make([]byte, udpBufferSize),
+		writeBuf: make([]byte, udpBufferSize),
+	}
+	if udpConn, ok := conn.(*net.UDPConn); ok {
+		return &obfsPacketConnUDP{
+			obfsPacketConn: obfsConn,
+			udpConn:        udpConn,
+		}
+	}
+	return obfsConn
+}
+
+func newSalamanderPacketConn(conn net.PacketConn, key []byte) (net.PacketConn, error) {
+	obfs, err := newSalamanderObfuscator(key)
+	if err != nil {
+		return nil, err
+	}
+	return newObfsPacketConn(conn, obfs), nil
+}
+
+func (c *obfsPacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
+	for {
+		c.readMutex.Lock()
+		n, addr, err = c.conn.ReadFrom(c.readBuf)
+		if n <= 0 {
+			c.readMutex.Unlock()
+			return n, addr, err
+		}
+		n = c.obfs.Deobfuscate(c.readBuf[:n], p)
+		c.readMutex.Unlock()
+		if n > 0 || err != nil {
+			return n, addr, err
+		}
+	}
+}
+
+func (c *obfsPacketConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
+	c.writeMutex.Lock()
+	nn := c.obfs.Obfuscate(p, c.writeBuf)
+	if nn == 0 {
+		c.writeMutex.Unlock()
+		return 0, fmt.Errorf("obfuscated packet is too large: %d bytes", len(p))
+	}
+	_, err = c.conn.WriteTo(c.writeBuf[:nn], addr)
+	c.writeMutex.Unlock()
+	if err == nil {
+		n = len(p)
+	}
+	return n, err
+}
+
+func (c *obfsPacketConn) Close() error {
+	return c.conn.Close()
+}
+
+func (c *obfsPacketConn) LocalAddr() net.Addr {
+	return c.conn.LocalAddr()
+}
+
+func (c *obfsPacketConn) SetDeadline(t time.Time) error {
+	return c.conn.SetDeadline(t)
+}
+
+func (c *obfsPacketConn) SetReadDeadline(t time.Time) error {
+	return c.conn.SetReadDeadline(t)
+}
+
+func (c *obfsPacketConn) SetWriteDeadline(t time.Time) error {
+	return c.conn.SetWriteDeadline(t)
+}
+
+func (c *obfsPacketConnUDP) SetReadBuffer(bytes int) error {
+	return c.udpConn.SetReadBuffer(bytes)
+}
+
+func (c *obfsPacketConnUDP) SetWriteBuffer(bytes int) error {
+	return c.udpConn.SetWriteBuffer(bytes)
+}
+
+func (c *obfsPacketConnUDP) SyscallConn() (syscall.RawConn, error) {
+	return c.udpConn.SyscallConn()
+}

--- a/protocol/hysteria2/client/salamander_test.go
+++ b/protocol/hysteria2/client/salamander_test.go
@@ -1,0 +1,103 @@
+package client
+
+import (
+	"errors"
+	"math/rand"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestSalamanderObfuscatorRoundTrip(t *testing.T) {
+	obfs, err := newSalamanderObfuscator([]byte("password"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	obfs.randSrc = rand.New(rand.NewSource(1))
+
+	payload := []byte("hello hysteria2 salamander")
+	encoded := make([]byte, len(payload)+salamanderSaltLen)
+	if n := obfs.Obfuscate(payload, encoded); n != len(encoded) {
+		t.Fatalf("Obfuscate() = %d, want %d", n, len(encoded))
+	}
+	if string(encoded[salamanderSaltLen:]) == string(payload) {
+		t.Fatal("payload was not obfuscated")
+	}
+
+	decoded := make([]byte, len(payload))
+	if n := obfs.Deobfuscate(encoded, decoded); n != len(payload) {
+		t.Fatalf("Deobfuscate() = %d, want %d", n, len(payload))
+	}
+	if string(decoded) != string(payload) {
+		t.Fatalf("round trip = %q, want %q", decoded, payload)
+	}
+}
+
+func TestSalamanderObfuscatorRejectsShortPSK(t *testing.T) {
+	if _, err := newSalamanderObfuscator([]byte("abc")); !errors.Is(err, errSalamanderPSKTooShort) {
+		t.Fatalf("newSalamanderObfuscator() error = %v, want %v", err, errSalamanderPSKTooShort)
+	}
+}
+
+func TestObfsPacketConnRejectsOversizedPacket(t *testing.T) {
+	obfs, err := newSalamanderObfuscator([]byte("password"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn := newObfsPacketConn(&stubPacketConn{}, obfs)
+
+	if _, err := conn.WriteTo(make([]byte, udpBufferSize), &net.UDPAddr{}); err == nil {
+		t.Fatal("WriteTo() error = nil, want oversized packet error")
+	}
+}
+
+func TestGenericObfsPacketConnDoesNotExposeUDPBufferOptions(t *testing.T) {
+	obfs, err := newSalamanderObfuscator([]byte("password"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn := newObfsPacketConn(&stubPacketConn{}, obfs)
+
+	if _, ok := conn.(interface{ SetReadBuffer(int) error }); ok {
+		t.Fatal("generic obfs packet conn unexpectedly exposes SetReadBuffer")
+	}
+	if _, ok := conn.(interface{ SetWriteBuffer(int) error }); ok {
+		t.Fatal("generic obfs packet conn unexpectedly exposes SetWriteBuffer")
+	}
+	if _, ok := conn.(interface {
+		SyscallConn() (syscall.RawConn, error)
+	}); ok {
+		t.Fatal("generic obfs packet conn unexpectedly exposes SyscallConn")
+	}
+}
+
+type stubPacketConn struct{}
+
+func (c *stubPacketConn) ReadFrom(_ []byte) (int, net.Addr, error) {
+	return 0, nil, errors.New("not implemented")
+}
+
+func (c *stubPacketConn) WriteTo(p []byte, _ net.Addr) (int, error) {
+	return len(p), nil
+}
+
+func (c *stubPacketConn) Close() error {
+	return nil
+}
+
+func (c *stubPacketConn) LocalAddr() net.Addr {
+	return &net.UDPAddr{}
+}
+
+func (c *stubPacketConn) SetDeadline(_ time.Time) error {
+	return nil
+}
+
+func (c *stubPacketConn) SetReadDeadline(_ time.Time) error {
+	return nil
+}
+
+func (c *stubPacketConn) SetWriteDeadline(_ time.Time) error {
+	return nil
+}

--- a/protocol/hysteria2/dialer.go
+++ b/protocol/hysteria2/dialer.go
@@ -24,8 +24,9 @@ type Dialer struct {
 }
 
 type Feature1 struct {
-	BandwidthConfig client.BandwidthConfig
-	UDPHopInterval  time.Duration
+	BandwidthConfig   client.BandwidthConfig
+	ObfuscationConfig client.ObfuscationConfig
+	UDPHopInterval    time.Duration
 }
 
 func NewDialer(nextDialer netproxy.Dialer, header protocol.Header) (netproxy.Dialer, error) {
@@ -53,6 +54,7 @@ func NewDialer(nextDialer netproxy.Dialer, header protocol.Header) (netproxy.Dia
 	}
 	if feature := header.Feature1; feature != nil {
 		config.BandwidthConfig = feature.(*Feature1).BandwidthConfig
+		config.ObfuscationConfig = feature.(*Feature1).ObfuscationConfig
 		config.UDPHopInterval = feature.(*Feature1).UDPHopInterval
 	}
 


### PR DESCRIPTION
## Summary
- add Hysteria2 Salamander obfuscation support for `obfs=salamander&obfs-password=...`
- wrap QUIC packets with the Hysteria v2 `[8-byte salt][payload]` format using BLAKE2b-256 over PSK+salt
- validate obfuscation settings, accept `plain`, normalize method casing, and preserve URI export
- add focused tests for round-trip obfuscation, short PSK rejection, oversized packet handling, and generic PacketConn capabilities

## Context
This covers the same feature area as #57, with a couple of hardening changes from testing against sing-box/Hysteria2 servers:
- avoid exposing UDP-specific buffer/syscall methods from the generic obfs wrapper
- validate the PSK before starting the QUIC handshake so invalid configuration fails fast instead of timing out
- normalize the `obfs` method case before validation/dialing

## Test
- `go test ./protocol/hysteria2/client ./dialer/hysteria2`
