### PR TITLE
fix: use KeyShareKeys.Ecdhe instead of deprecated EcdheKey for Reality

### DIFF
--- a/transport/tls/reality.go
+++ b/transport/tls/reality.go
@@ -213,7 +213,14 @@ func (x *Reality) DialContext(ctx context.Context, network, addr string) (c netp
 			// if config.Show {
 			// logrus.Printf("REALITY hello.SessionId[:16]: %v\n", hello.SessionId[:16])
 			// }
-			if uConn.HandshakeState.State13.EcdheKey == nil {
+			var ecdheKey *ecdh.PrivateKey
+			if uConn.HandshakeState.State13.KeyShareKeys != nil {
+				ecdheKey = uConn.HandshakeState.State13.KeyShareKeys.Ecdhe
+			}
+			if ecdheKey == nil {
+				ecdheKey = uConn.HandshakeState.State13.EcdheKey // fallback to deprecated field
+			}
+			if ecdheKey == nil {
 				// logrus.Println("wtf", retry, addr)
 				if retry > 2 {
 					return nil, errors.New("nil ecdheKey")
@@ -222,7 +229,7 @@ func (x *Reality) DialContext(ctx context.Context, network, addr string) (c netp
 				goto retryHandshake // retry
 			}
 			// logrus.Println("OH YEAH", retry)
-			uConn.AuthKey, _ = uConn.HandshakeState.State13.EcdheKey.ECDH(x.publicKey)
+			uConn.AuthKey, _ = ecdheKey.ECDH(x.publicKey)
 			if uConn.AuthKey == nil {
 				return nil, errors.New("REALITY: SharedKey == nil")
 			}


### PR DESCRIPTION
## Problem
VLESS Reality nodes fail with `nil ecdheKey` in dae v1.1.0.
Root cause: `reality.go` reads `uConn.HandshakeState.State13.EcdheKey`,
but newer uTLS versions (v1.8+, used in dae v1.1.0) have deprecated this field
in favor of `State13.KeyShareKeys.Ecdhe`.

`BuildHandshakeState()` populates `KeyShareKeys` (confirmed at uTLS `u_conn.go:122`):
```go
uconn.HandshakeState.State13.KeyShareKeys = keySharePrivate.ToPublic()
```
But the deprecated `EcdheKey` may remain nil, causing all Reality connections to fail
after 3 retries.

## Fix
- Prefer `State13.KeyShareKeys.Ecdhe` (new API)
- Fall back to `State13.EcdheKey` for backward compatibility
- Only retry if both are nil

## Related
- daeuniverse/dae#873: vless connectivity check failed
- daeuniverse/dae#876: reality random disconnect
- daeuniverse/dae#983: nil ecdheKey

## References
- Same class of bug: sing-box#2084 (chrome_pq fingerprint + Reality = nil ecdhe_key)
- uTLS: `u_public.go:50` defines `KeyShareKeys *KeySharePrivateKeys`